### PR TITLE
Refactor collision detection to use numpy SDF

### DIFF
--- a/mrrt/collision_detection.py
+++ b/mrrt/collision_detection.py
@@ -1,13 +1,11 @@
-from .sdf import *
+from .distance import distance_between_objects
+from .rotation_utils import pave_short_edge
 
-from .distance import *
-from .rotation_utils import *
-
-def is_collision(mesh1, q1, mesh2, q2, threshold, device):
-    dist = distance_between_objects(mesh1, q1, mesh2, q2, device)
+def is_collision(mesh1, q1, mesh2, q2, threshold, device=None):
+    dist = distance_between_objects(mesh1, q1, mesh2, q2)
     return dist < threshold
 
-def is_edge_valid(mesh_static, q_static, mesh_dynamic, q_start, q_end, n, threshold, device):
+def is_edge_valid(mesh_static, q_static, mesh_dynamic, q_start, q_end, n, threshold, device=None):
     """
     varify validity (clearance) of n points evenly spread along the edge from q_start to q_end
     :param q_start: starting point (configuration)
@@ -18,7 +16,6 @@ def is_edge_valid(mesh_static, q_static, mesh_dynamic, q_start, q_end, n, thresh
     qs = pave_short_edge(q_start, q_end, n)
 
     for q in qs:
-        if is_collision(mesh_static, q_static, mesh_dynamic, q, threshold, device):
+        if is_collision(mesh_static, q_static, mesh_dynamic, q, threshold):
             return False
-
     return True

--- a/mrrt/distance.py
+++ b/mrrt/distance.py
@@ -1,6 +1,8 @@
-from .sdf import *
+import numpy as np
 
-def distance_between_objects(mesh1, q1, mesh2, q2, device, single_direction=False):
+from .sdf import signed_distance
+
+def distance_between_objects(mesh1, q1, mesh2, q2, device=None, single_direction=False):
     """
     actual distance between two pieces (mesh1, mesh2) when located in configurations q1 and q2 respectively
     :param mesh1:
@@ -9,7 +11,7 @@ def distance_between_objects(mesh1, q1, mesh2, q2, device, single_direction=Fals
     :param q2:
     :return: float. distance between units
     """
-    return signed_distance(mesh1, xyzrpy_2_SE3(q1), mesh2, xyzrpy_2_SE3(q2), device, single_direction)
+    return signed_distance(mesh1, q1, mesh2, q2, single_direction)
 
 def distance_between_configurations(q1: list, q2: list):
     """

--- a/mrrt/sdf/__init__.py
+++ b/mrrt/sdf/__init__.py
@@ -1,17 +1,3 @@
-import tqdm
-import numpy as np
-from spatialmath import SE3
-
-import torch
-import torch.nn as nn
-import torch.optim as optim
-from torch.utils.data import DataLoader
-
-from .model import *
-from .train import *
-from .dataset import *
-from .to_mesh import *
-from .sdf_mesh import *
-from .signed_distance import *
-from .sdf_gradients import *
+from .sdf_mesh import SDFMesh
+from .signed_distance import signed_distance
 from .conversions import *

--- a/mrrt/sdf/conversions.py
+++ b/mrrt/sdf/conversions.py
@@ -1,86 +1,42 @@
-import torch
-from spatialmath import SE3
+import numpy as np
 
-def SE3_2_xyzrpy(se3):
-    return list(se3.t) + list(se3.rpy(order='xyz'))
+
+def SE3_2_xyzrpy(T):
+    """Convert a 4x4 transformation matrix to xyz+rpy."""
+    x, y, z = T[:3, 3]
+    sy = -T[2, 0]
+    cy = np.sqrt(1 - sy ** 2)
+    if cy < 1e-6:
+        rx = np.arctan2(-T[1, 2], T[1, 1])
+        ry = np.arcsin(sy)
+        rz = 0
+    else:
+        rx = np.arctan2(T[2, 1], T[2, 2])
+        ry = np.arctan2(sy, cy)
+        rz = np.arctan2(T[1, 0], T[0, 0])
+    return [x, y, z, rx, ry, rz]
+
 
 def xyzrpy_2_SE3(q):
-    return SE3(q[:3]) * SE3.RPY(q[3:], order='xyz')
+    """Convert xyz+rpy to a 4x4 transformation matrix."""
+    x, y, z, rx, ry, rz = q
+    cx, cy, cz = np.cos([rx, ry, rz])
+    sx, sy, sz = np.sin([rx, ry, rz])
+    Rz = np.array([[cz, -sz, 0], [sz, cz, 0], [0, 0, 1]])
+    Ry = np.array([[cy, 0, sy], [0, 1, 0], [-sy, 0, cy]])
+    Rx = np.array([[1, 0, 0], [0, cx, -sx], [0, sx, cx]])
+    R = Rz @ Ry @ Rx
+    T = np.eye(4)
+    T[:3, :3] = R
+    T[:3, 3] = [x, y, z]
+    return T
 
-def list_2_tensor_with_grad(q, device):
-    return torch.tensor(q).to(device).float().requires_grad_(True)
+
+def list_2_tensor_with_grad(q, device=None):
+    """Compatibility wrapper returning a numpy array."""
+    return np.array(q, dtype=float)
 
 
-# try:
-#     import pytorch3d.transforms
-
-#     def euler_to_matrix(euler_xyz, device):
-#         rotation = pytorch3d.transforms.euler_angles_to_matrix(euler_xyz[3:], 'XYZ')
-#         t = pytorch3d.transforms.Transform3d(device=device).rotate(rotation).translate(*euler_xyz[:3])
-#         return torch.transpose(t.get_matrix().reshape((4,4)), 0, 1)
-
-# except ImportError:
-def euler_to_matrix(euler_xyz, device):
-    """
-    Convert a tensor of shape (6,) with xyz and euler angles values to a 4x4 corresponding transformation matrix.
-    
-    Args:
-    euler_xyz: torch.Tensor of shape (6,) containing xyz and euler angles values
-    
-    Returns:
-    transform_matrix: torch.Tensor of shape (4, 4) representing the transformation matrix
-    """
-    
-    # Extract xyz and euler angles from the input tensor
-    x, y, z, rx, ry, rz = euler_xyz
-    
-    x = x.reshape((1,))
-    y = y.reshape((1,))
-    z = z.reshape((1,))
-    # Compute sine and cosine of the euler angles
-    c_rx, s_rx = torch.cos(rx).reshape((1,)), torch.sin(rx).reshape((1,))
-    c_ry, s_ry = torch.cos(ry).reshape((1,)), torch.sin(ry).reshape((1,))
-    c_rz, s_rz = torch.cos(rz).reshape((1,)), torch.sin(rz).reshape((1,))
-    one = torch.tensor(1.0).reshape((1,)).to(device)
-    zero = torch.tensor(0.0).reshape((1,)).to(device)
-    
-    # Create the rotation matrices
-    Rx = torch.cat([
-        one, zero, zero, zero,
-        zero, c_rx, -s_rx, zero,
-        zero, s_rx, c_rx, zero,
-        zero, zero, zero, one
-    ]).reshape((4,4))
-    Ry = torch.cat([
-        c_ry, zero, s_ry, zero,
-        zero, one, zero, zero,
-        -s_ry, zero, c_ry, zero,
-        zero, zero, zero, one
-    ]).reshape((4,4))
-    Rz = torch.cat([
-        c_rz, -s_rz, zero, zero,
-        s_rz, c_rz, zero, zero, 
-        zero, zero, one, zero,
-        zero, zero, zero, one
-    ]).reshape((4,4))
-    R = torch.matmul(torch.matmul(Rx, Ry), Rz).reshape((16,))
-    r11, r12, r13, _, r21, r22, r23, _, r31, r32, r33, _, _, _, _, _ = R
-    R = torch.cat([
-        r33.reshape((1,)), r23.reshape((1,)), r13.reshape((1,)), zero,
-        r32.reshape((1,)), r22.reshape((1,)), r12.reshape((1,)), zero,
-        r31.reshape((1,)), r21.reshape((1,)), r11.reshape((1,)), zero,
-        zero, zero, zero, one
-    ]).reshape((4,4))
-
-    # Create the translation vector
-    T = torch.cat([
-        one, zero, zero, x,
-        zero, one, zero, y,
-        zero, zero, one, z,
-        zero, zero, zero, one
-    ]).reshape((4,4))
-    
-    # Create the transformation matrix
-    transform_matrix = torch.matmul(T, R)
-    
-    return transform_matrix
+def euler_to_matrix(euler_xyz, device=None):
+    """Convert xyz+euler angles to a 4x4 transformation matrix."""
+    return xyzrpy_2_SE3(euler_xyz)

--- a/mrrt/sdf/sdf_mesh.py
+++ b/mrrt/sdf/sdf_mesh.py
@@ -1,68 +1,63 @@
-import tqdm
 import numpy as np
-from spatialmath import SE3
-
-import torch
-import torch.nn as nn
-import torch.optim as optim
-from torch.utils.data import DataLoader
-
-from .model import *
-from .train import *
-from .dataset import *
-from .to_mesh import *
+import trimesh
 
 
-class SDFMesh(object):
-    """
-    Class for an SDF representation of a mesh
-    """
-    def __init__(self, mesh_path, device, vis=None):
+class SDFMesh:
+    """Simple SDF representation loaded from an ``*.npz`` file."""
+
+    def __init__(self, mesh_path, device=None, vis=None):
         self.mesh_path = mesh_path
-        self.device = device
-        self.vis = vis
-        self.model = SDFModel().to(self.device)
         self.sampling = None
         self.mesh = None
-    
-    def fit(self, num_samples=1000000, num_epochs=100, lr=1e-4, batch_size=128):
-        self.train_dataset = SDFDataset(
-            mesh_path=self.mesh_path, num_samples=num_samples)
-        self.train_loader = DataLoader(
-            self.train_dataset, batch_size=batch_size, 
-            num_workers=1, pin_memory=True, shuffle=True)
-        self._update_model_scale()
-
-        self.criterion = nn.L1Loss(reduction='sum')
-        self.optimizer = optim.Adam(self.model.parameters(), lr=lr)
-
-        train_losses = []
-        for epoch in range(num_epochs):
-            self.vis.text('Epoch: {}/{} ({:.2f}%)'.format(epoch + 1, num_epochs, (epoch + 1) / num_epochs * 100.0), opts={'title': "Current epoch"}, win='curr_epoch')
-            train(self.train_loader, self.model, self.device,
-                self.criterion, self.optimizer, epoch, train_losses, self.vis)
-            if epoch % 10 == 0 or True:
-                torch.save(self.model.state_dict(), self.mesh_path + '.pth')
-        torch.save(self.model.state_dict(), self.mesh_path + '.pth')
-        return train_losses
+        self.sdf = None
+        self.origin = None
+        self.voxel_size = None
 
     def load(self):
-        self._update_model_scale()
-        self.model.load_state_dict(torch.load(self.mesh_path + '.pth', map_location=torch.device('cpu')))
-        self.model.to(self.device)
+        """Load the pre-computed SDF grid from ``mesh_path + '.npz'``."""
+        data = np.load(self.mesh_path + '.npz')
+        self.sdf = data['sdf']
+        self.origin = data['origin']
+        self.voxel_size = float(data['voxel_size'])
         self.mesh = trimesh.load(self.mesh_path)
         self.pq = trimesh.proximity.ProximityQuery(self.mesh)
 
-    def to_mesh(self, output_name, n=100):
-        return sdf_to_mesh(self.model, n, self.device, self.centroid, self.max_norm, output_name)
-
     def generate_sampling(self, num_samples):
+        """Generate ``num_samples`` surface points for collision queries."""
         if self.mesh is None:
             self.mesh = trimesh.load(self.mesh_path)
-        self.sampling, _ = trimesh.sample.sample_surface(self.mesh, num_samples, face_weight=None)
-       
+        self.sampling, _ = trimesh.sample.sample_surface(
+            self.mesh, num_samples, face_weight=None
+        )
 
-    def _update_model_scale(self):
-        mesh = trimesh.load(self.mesh_path)
-        self.centroid = mesh.centroid
-        self.max_norm = np.linalg.norm(np.max(mesh.vertices - mesh.centroid))
+    def query(self, points):
+        """Tri-linearly interpolate SDF values at given points."""
+        pts = np.asarray(points)
+        coords = (pts - self.origin) / self.voxel_size
+        i0 = np.floor(coords).astype(int)
+        d = coords - i0
+        max_idx = np.array(self.sdf.shape) - 2
+        i0 = np.clip(i0, 0, max_idx)
+        i1 = i0 + 1
+
+        x0, y0, z0 = i0[:, 0], i0[:, 1], i0[:, 2]
+        x1, y1, z1 = i1[:, 0], i1[:, 1], i1[:, 2]
+        tx, ty, tz = d[:, 0], d[:, 1], d[:, 2]
+        g = self.sdf
+
+        c000 = g[x0, y0, z0]
+        c100 = g[x1, y0, z0]
+        c010 = g[x0, y1, z0]
+        c110 = g[x1, y1, z0]
+        c001 = g[x0, y0, z1]
+        c101 = g[x1, y0, z1]
+        c011 = g[x0, y1, z1]
+        c111 = g[x1, y1, z1]
+
+        c00 = c000 * (1 - tx) + c100 * tx
+        c10 = c010 * (1 - tx) + c110 * tx
+        c01 = c001 * (1 - tx) + c101 * tx
+        c11 = c011 * (1 - tx) + c111 * tx
+        c0 = c00 * (1 - ty) + c10 * ty
+        c1 = c01 * (1 - ty) + c11 * ty
+        return c0 * (1 - tz) + c1 * tz

--- a/mrrt/sdf/signed_distance.py
+++ b/mrrt/sdf/signed_distance.py
@@ -1,37 +1,30 @@
-import tqdm
 import numpy as np
-from spatialmath import SE3
 
-import torch
-import torch.nn as nn
-import torch.optim as optim
-from torch.utils.data import DataLoader
-
-from .sdf_mesh import *
+from .sdf_mesh import SDFMesh
+from .conversions import xyzrpy_2_SE3
 
 
-def signed_distance_one_directional(m1: SDFMesh, q1: SE3, m2: SDFMesh, q2: SE3, device):
+def transform_points(T, points):
+    pts_h = np.hstack([points, np.ones((points.shape[0], 1))])
+    return (T @ pts_h.T).T[:, :3]
+
+
+def signed_distance_one_directional(m1: SDFMesh, T1, m2: SDFMesh, T2):
     if m2.sampling is None:
         raise ValueError("SDFMesh (m2) should have sampling")
-    
-    # move m1 back to original pose
-    q = SE3(*-m1.centroid) * q1.inv() * q2
-    samples = ((q * m2.sampling.T) / m1.max_norm).T
-    samples = torch.from_numpy(samples).float().to(device)
-    model_samples = m1.model(samples)
-    maxx = torch.max(model_samples)
-    val = (-maxx * m1.max_norm).item()
-    return val
+    T = np.linalg.inv(T1) @ T2
+    samples = transform_points(T, m2.sampling)
+    distances = m1.query(samples)
+    return -np.max(distances)
 
-def signed_distance(m1: SDFMesh, q1: SE3, m2: SDFMesh, q2: SE3, device, single_direction=False):
-    """
-    Compute signed distance between two meshes in 3D space.
-    The transformations q1,q2 \in SE(3) are in the original (un-scaled) model space.
-    We take sampling on the second mesh, and compare with the SDF of the first.
-    """
-    val_1 = signed_distance_one_directional(m1, q1, m2, q2, device)
+
+def signed_distance(m1: SDFMesh, q1, m2: SDFMesh, q2, single_direction=False):
+    """Compute signed distance between two meshes using pre-computed SDF grids."""
+    T1 = xyzrpy_2_SE3(q1)
+    T2 = xyzrpy_2_SE3(q2)
+    val_1 = signed_distance_one_directional(m1, T1, m2, T2)
     if single_direction:
         val_2 = val_1
     else:
-        val_2 = signed_distance_one_directional(m2, q2, m1, q1, device)
+        val_2 = signed_distance_one_directional(m2, T2, m1, T1)
     return min(val_1, val_2)

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,6 +1,6 @@
-from mrrt.sdf import *
-from mrrt.rrt import *
-from mrrt.visualize import *
+from mrrt.sdf import SDFMesh
+from mrrt.rrt import RRT
+from mrrt.visualize import BulletVisualization
 
 import os
 import time
@@ -19,16 +19,9 @@ if not os.path.isdir(BASE_RESULTS_DIR):
 
 
 ###############
-# Setup torch
+# Setup device placeholder
 ###############
-MACOS_USE_MPS = False
-if platform.system() == "Darwin" and MACOS_USE_MPS:
-    # Test for M1 GPUs
-    device = torch.device('mps' if torch.backends.mps.is_available() and torch.backends.mps.is_built() else 'cpu')
-else:
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
-print(device)
+device = None
 
 ###############
 # Setup args

--- a/scripts/visualize_path.py
+++ b/scripts/visualize_path.py
@@ -1,6 +1,6 @@
-from mrrt.sdf import *
-from mrrt.rrt import *
-from mrrt.visualize import *
+from mrrt.sdf import SDFMesh
+from mrrt.rrt import RRT
+from mrrt.visualize import BulletVisualization
 
 import os
 import time
@@ -19,16 +19,9 @@ if not os.path.isdir(BASE_RESULTS_DIR):
 
 
 ###############
-# Setup torch
+# Setup device placeholder
 ###############
-MACOS_USE_MPS = False
-if platform.system() == "Darwin" and MACOS_USE_MPS:
-    # Test for M1 GPUs
-    device = torch.device('mps' if torch.backends.mps.is_available() and torch.backends.mps.is_built() else 'cpu')
-else:
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-
-print(device)
+device = None
 
 ###############
 # Setup args


### PR DESCRIPTION
## Summary
- drop torch dependency from the runtime SDF code
- implement `SDFMesh` loading npz grids and trilinear sampling
- rewrite signed distance computation with numpy
- simplify conversions and collision detection utilities
- update example scripts to work without torch

## Testing
- `python -m py_compile mrrt/collision_detection.py mrrt/distance.py mrrt/sdf/__init__.py mrrt/sdf/conversions.py mrrt/sdf/sdf_mesh.py mrrt/sdf/signed_distance.py scripts/run_tests.py scripts/visualize_path.py`

------
https://chatgpt.com/codex/tasks/task_e_686686db17b48328a9603c0ab107bf46